### PR TITLE
Rpc proposal

### DIFF
--- a/src/rpc.h
+++ b/src/rpc.h
@@ -1,0 +1,185 @@
+#ifndef __RPC_H
+#define __RPC_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+// This assumes two unidirectional SPSC queues, find way to generalize
+// Unsure how much to keep in this ref, is 
+// there value in keeping all three
+// pairs of keys, shmid, and ref? in case of an issue where reconnect might be attempted?
+typedef struct queue_ref {
+    void* shm_request_shmaddr;
+    void* shm_response_shmaddr;
+} queue_ref;
+
+typedef struct client_queue {
+    uint64_t id;
+    queue_ref queue;
+} client_conn;
+
+typedef struct connection {
+    uint64_t id; // client id
+    char* address; // IP/Port Pair
+    uint8_t port; // Port 
+    void* coord_shmaddr; //Gotten after shmat
+    queue_ref queue; // Reference to underlying shm queue mechanism
+} connection; 
+
+struct connection_handler {
+    char* address; // IP/Port pair
+    key_t coord_key; // Hashed from IP and Port
+    void* coord_shmaddr;
+    client_queue* client_queues; //Queues used to by live client connection. TODO: Fixed array
+    queue_ref* free_queues; //Available queues to be assigned to new clients.  TODO: Fixed array
+};
+//NOTE ON ERROR HANDLING
+// As this is a low level C library we should use the global 
+// errno on failure. A lot of potential issues that can occur 
+// are related to the access and management of the SHM layer
+// which we can transparently utilize. 
+
+
+//SYNCHRONOUS
+ 
+//CLIENT
+/**
+ * @brief Client attempts a connection to a known instantiated 
+ * and listening Notnets server. This process involves hashing
+ * the address to resolve for a unique shm region key in which
+ * a coord request for a new queue pair can be made. This can 
+ * fail due to the server not having initialized its coord region,
+ * no available reserve slots. 
+ * 
+ * @param address[IN] Unique string to identify server address,
+ * usually IP/Port pair
+ * @return connection* If NULL, no connection was achieved
+ */
+connection* connection_init(uint64_t id, char* address);
+/**
+ * @brief Client writes to request queue in given connection.
+ * 
+ * @param buf[IN] data buf to be written
+ * @param size[IN] size of buf
+ * @param conn[IN] connection initialized with server
+ * @return ssize_t -1 for error, >0 for bytes written
+ */
+ssize_t notnets_conn_write(const void *buf, size_t size, connection* conn);
+
+/**
+  * @brief Client reads from response queue in given connection.
+ * TODO: Question: Should read be preallocated? Message size will be determined
+ * by the server writing the response. This will be the message in the response queue.  
+ * 
+ * This is complicated and worth of discussion. Many different design decisions:
+ * 1. Incur a data copy, server allocates and copies of the shm queue 
+ * 2. Make a really really big buffer that makes queue pressure unlikely?
+ * 3. Shm memory allocator and only pointers are passed in the queue, once the read has occurred
+ * we can confidently dequeue it, however we still have to manage the other allocated function.
+ * This is (kinda) the design approach taken by the paper.  Partial Failure Resilient Memory Management System for (CXL-based) Distributed Shared Memory. It requires a change of interface and garbage collecting.
+ * 4. Unsure of how CXL work but maybe, could you get a handle to the nic's packet buffers of the wire
+ * and map them to the process's address space. The nic would have to have a way of recognizing a
+ * particular message, and separate them from the usual buffers and pass the responsibility for freeing
+ * those buffers to the notnets process? This is how TCP zero copy kinda works but the memory mapping
+ * introduces overhead. If you could have a set region so that you had a single mapping it might not be so bad.
+ * 5. Transformation function? Pass a function into the read that ensures that overwritten would not be a problem. I'm imagining this to be a serialization function that would carry out the read and the subsequent necessary data transformation. This might be quite difficult to implement in certain frameworks, and is def a bit of a hack. 
+ * - Alternative, ensure this function only gets called when transformed? Very framework dependent
+ * 6. Allocate at enqueue in common page, pass by reference in actual queue. Flush at timeout? 
+ * 
+ * @param size[OUT] 
+ * @param conn[IN] 
+ * @return void* pointer to memory buffer containing message
+ */
+void* notnets_conn_read(ssize_t *size, connection* conn);
+
+/**
+ * @brief Closes the client connection. Signal to server
+ * to free up its reserved slot in Coord, and detachment 
+ * of shm queues. 
+ * 
+ * @param conn[IN] connection initialized with server
+ */
+void close(connection* conn);
+
+//SERVER
+/**
+ * @brief Server will instantiate necessary coord memory regions. 
+ * Once instantiate server can begin servicing client requests
+ * 
+ * 1. Invoked at instantiation of server. Only once per server
+ * 
+ * @param address[IN] Unique string to identify desired server address,
+ * usually IP/Port pair
+ * @return connection_handler* If NULL, coord memory region was not 
+ * created successfully 
+ */
+connection_handler* handler_init(char* address);
+
+/**
+ * @brief TODO: What is the ideal approach here?
+ * Currently the handler state would be updated 
+ * with the state of clients and queues in coord. 
+ * Blocking function for the rest client, 
+ * 
+ * 1. Needs to be periodically run to service 
+ * client requests: connection_init, stop
+ * 
+ * @param handler[IN/OUT] server client connection handler
+ */
+void handler_service_conn_requests(connection_handler* handler);
+
+/**
+ * 
+ * @brief TODO: Unsure about this implementation. Write single message
+ * to client response queue.
+ * The client to be written to must be known when calling this function.
+ * A generalized write would not make sense.
+ * The handler state should not be modified in this call. 
+ * 
+ * @param buf[IN] data buf to be written
+ * @param size[IN] size of buf
+ * @param client[IN] client details to write to.
+ * @return ssize_t  -1 for error, >0 for bytes written
+ */
+ssize_t handler_write_to_client(const void *buf, size_t size, client_queue* client);
+/**
+ * @brief Read single message of given client request queue. 
+ * TODO: Question: Should read be preallocated? Message size will be determined
+ * by the client. Probs not used
+ * 
+ * @param buf[OUT] data buf for data to be read into
+ * @param size[OUT] size of read to be performed
+ * @param client[IN] connection initialized with server
+ * @return ssize_t -1 for error, >0 for bytes read
+ */
+ssize_t handler_read_single_conn(void *buf, size_t *size,  client_queue* client);
+/**
+ * @brief This method is a generic read to read a single incoming request
+ * from any client. The order of these reads will depend on a queuing algorithm,
+ * ie. round robin, fifo, etc... We can choose to transparent the queuing methodology
+ * for whatever consuming system that uses this.
+ * TODO: Question: Should read be preallocated? Message size will be determined
+ * by the client.
+ * TODO: What is the correct way to read incoming messages? 
+ * - Round robin
+ * 
+ * @param buf [OUT] data buf for data to be read into
+ * @param size [OUT] size of read to be performed
+ * @param handler [IN] server client connection handler
+ * @return ssize_t -1 for error, >0 for bytes read
+ */
+void* handler_read(size_t *size, connection_handler* handler, client_queue** client);
+
+
+
+/**
+ * @brief Gracefully shutdown coord and all queues. Signal
+ * and wait until clients do so. 
+ * 
+ * @param handler [IN] server client connection handler
+ */
+void shutdown(connection_handler* handler);
+
+#endif

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -10,39 +10,21 @@
 // Unsure how much to keep in this ref, is 
 // there value in keeping all three
 // pairs of keys, shmid, and ref? in case of an issue where reconnect might be attempted?
-typedef struct queue_ref {
+typedef struct queue_pair {
+    uint64_t id;
     void* shm_request_shmaddr;
     void* shm_response_shmaddr;
-} queue_ref;
+} queue_pair;
 
-typedef struct client_queue {
-    uint64_t id;
-    queue_ref queue;
-} client_conn;
-
-typedef struct connection {
-    uint64_t id; // client id
-    char* address; // IP/Port Pair
-    uint8_t port; // Port 
-    void* coord_shmaddr; //Gotten after shmat
-    queue_ref queue; // Reference to underlying shm queue mechanism
-} connection; 
-
-struct connection_handler {
-    char* address; // IP/Port pair
-    key_t coord_key; // Hashed from IP and Port
+struct server_context {
     void* coord_shmaddr;
-    client_queue* client_queues; //Queues used to by live client connection. TODO: Fixed array
-    queue_ref* free_queues; //Available queues to be assigned to new clients.  TODO: Fixed array
 };
-
 
 //NOTE ON ERROR HANDLING
 // As this is a low level C library we should use the global 
 // errno on failure. A lot of potential issues that can occur 
 // are related to the access and management of the SHM layer
 // which we can transparently utilize. 
-
 
 //SYNCHRONOUS
  
@@ -55,61 +37,61 @@ struct connection_handler {
  * fail due to the server not having initialized its coord region,
  * no available reserve slots. 
  * 
+ * // Client ID: Client Address + Nonce.
+ * // It is an identifier IP and Sequence Number 
+ * 
  * @param address[IN] Unique string to identify server address,
  * usually IP/Port pair
  * @return connection* If NULL, no connection was achieved
  */
-connection* connection_init(uint64_t id, char* address);
+queue_pair* open(char* source_addr, char* destination_addr);
+
+
 /**
  * @brief Client writes to request queue in given connection.
  * 
+ * TODO: 
+ * - What if queue full? return 0 for bytes written
+ * 
  * @param buf[IN] data buf to be written
  * @param size[IN] size of buf
- * @param conn[IN] connection initialized with server
+ * @param conn[IN] queues initialized with server
  * @return ssize_t -1 for error, >0 for bytes written
  */
-ssize_t notnets_conn_write(const void *buf, size_t size, connection* conn);
+ssize_t send_rpc(queue_pair* conn, const void *buf, size_t size);
+
 
 /**
-  * @brief Client reads from response queue in given connection.
- * TODO: Question: Should read be preallocated? Message size will be determined
- * by the server writing the response. This will be the message in the response queue. 
+ * @brief Buffer provided by user. Called until all data has been read from 
+ * message queue.
  * 
- * TODO: Issue. Current queue design assumes that a read by a consumer of the 
- * queue will update the flag that permits the producer to keep on writing. 
- * Changing this might add significant complexity to the queue. However, if 
- * in order to avoid a data copy our read only returns a reference to the 
- * message in the queue we cannot ensure that the message is dereferenced 
- * before it is overwritten. A brainstorm of potential solutions follows below.  
+ * TODO: How do we keep track in the message queue how much has been written?
  * 
- * This is complicated and worth of discussion. Many different design decisions:
- * 1. Incur a data copy, server allocates and copies of the shm queue 
- * 2. Make a really really big buffer that makes queue pressure unlikely?
- * 3. Shm memory allocator and only pointers are passed in the queue, once the read has occurred
- * we can confidently dequeue it, however we still have to manage the other allocated function.
- * This is (kinda) the design approach taken by the paper.  Partial Failure Resilient Memory Management System for (CXL-based) Distributed Shared Memory. It requires a change of interface and garbage collecting.
- * 4. Unsure of how CXL work but maybe, could you get a handle to the nic's packet buffers of the wire
- * and map them to the process's address space. The nic would have to have a way of recognizing a
- * particular message, and separate them from the usual buffers and pass the responsibility for freeing
- * those buffers to the notnets process? This is how TCP zero copy kinda works but the memory mapping
- * introduces overhead. If you could have a set region so that you had a single mapping it might not be so bad.
- * 5. Transformation function? Pass a function into the read that ensures that overwritten would not be a problem. I'm imagining this to be a serialization function that would carry out the read and the subsequent necessary data transformation. This might be quite difficult to implement in certain frameworks, and is def a bit of a hack. 
- * - Alternative, ensure this function only gets called when transformed? Very framework dependent
  * 
- * @param size[OUT] 
- * @param conn[IN] 
- * @return void* pointer to memory buffer containing message
+ * @param conn [IN] queues initialized with server
+ * @param buf [IN] data buf to be copied to
+ * @param size [IN] size of buf
+ * @return ssize_t How much read, if 0 EOF. Only removed from queue once fully read. 
  */
-void* notnets_conn_read(ssize_t *size, connection* conn);
+ssize_t receive_rpc(queue_pair* conn, void** buf, size_t size);
+
 
 /**
  * @brief Closes the client connection. Signal to server
  * to free up its reserved slot in Coord, and detachment 
  * of shm queues. 
  * 
+ * TODO: not urgent,
+ * - invalid clients
+ * - dont close the same thing twice
+ * - malformed
+ * - ERRNO
+ * 
  * @param conn[IN] connection initialized with server
  */
-void close(connection* conn);
+void close(char* source_addr, char* destination_addr);
+
+
 
 //SERVER
 /**
@@ -118,51 +100,65 @@ void close(connection* conn);
  * 
  * 1. Invoked at instantiation of server. Only once per server
  * 
- * @param address[IN] Unique string to identify desired server address,
+ * @param source_addr[IN] Unique string to identify desired server address,
  * usually IP/Port pair
- * @return connection_handler* If NULL, coord memory region was not 
+ * @return server_context* If NULL, coord memory region was not 
  * created successfully 
  */
-connection_handler* handler_init(char* address);
+server_context* register_server(char* source_addr);
+
 
 /**
- * @brief TODO: What is the ideal approach here?
- * Currently the handler state would be updated 
- * with the state of clients and queues in coord. 
- * Blocking function for the rest client, 
+ * @brief
+ * 
+ * Returns a queue pair corresponding to a client who requested it.
+ * Will only service one client per call? In round robin, cycles
+ * through currently servicing clients and returns queue pair accordingly.
+ * This differs from the usual listen/accept pattern
  * 
  * 1. Needs to be periodically run to service 
- * client requests: connection_init, stop
+ * client requests: open, close
  * 
  * @param handler[IN/OUT] server client connection handler
  */
-void handler_service_conn_requests(connection_handler* handler);
+queue_pair* listen(server_context* handler);
+
 
 /**
+ * @brief 
  * 
- * @brief TODO: Unsure about this implementation. Write single message
- * to client response queue.
- * The client to be written to must be known when calling this function.
- * A generalized write would not make sense.
- * The handler state should not be modified in this call. 
+ * Service client requests, allocate communication queues, and
+ * signal to clients their details. Modifies coord space.
  * 
+ * @param handler [IN/OUT] server client connection handler
+ * @return queue_pair 
+ */
+int manage_conn(server_context* handler);
+
+
+/**
+ * @brief The client must be identified before written to. 
+ * 
+ * @param client[IN] queue pair 
  * @param buf[IN] data buf to be written
  * @param size[IN] size of buf
- * @param client[IN] client details to write to.
  * @return ssize_t  -1 for error, >0 for bytes written
  */
-ssize_t handler_write_to_client(const void *buf, size_t size, client_queue* client);
+ssize_t send_rpc(queue_pair* client, const void *buf, size_t size);
+
 /**
- * @brief Read single message of given client request queue. 
- * TODO: Question: Should read be preallocated? Message size will be determined
- * by the client. Probs not used
+ * @brief Buffer provided by user. Called until all data has been read from 
+ * message queue.
  * 
- * @param buf[OUT] data buf for data to be read into
- * @param size[OUT] size of read to be performed
- * @param client[IN] connection initialized with server
- * @return ssize_t -1 for error, >0 for bytes read
+ * TODO: How do we keep track in the message queue how much has been written?
+ * 
+ * @param client [IN] queue pair
+ * @param buf [IN] data buf to be copied to
+ * @param size [IN] size of buf
+ * @return ssize_t How much read, if 0 EOF. Only removed from queue once fully read. 
  */
-ssize_t handler_read_single_conn(void *buf, size_t *size,  client_queue* client);
+ssize_t receive_rpc(queue_pair* client, void** buf, size_t size);
+
 /**
  * @brief This method is a generic read to read a single incoming request
  * from any client. The order of these reads will depend on a queuing algorithm,
@@ -183,8 +179,7 @@ ssize_t handler_read_single_conn(void *buf, size_t *size,  client_queue* client)
  * @param handler [IN] server client connection handler
  * @return ssize_t -1 for error, >0 for bytes read
  */
-void* handler_read(size_t *size, connection_handler* handler, client_queue** client);
-
+void* receive_next_rpc(size_t *size, server_context* handler, queue_pair** client);
 
 
 /**
@@ -193,6 +188,6 @@ void* handler_read(size_t *size, connection_handler* handler, client_queue** cli
  * 
  * @param handler [IN] server client connection handler
  */
-void shutdown(connection_handler* handler);
+void shutdown(server_context* handler);
 
 #endif

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -35,12 +35,11 @@ struct server_context {
  * the address to resolve for a unique shm region key in which
  * a coord request for a new queue pair can be made. This can 
  * fail due to the server not having initialized its coord region,
- * no available reserve slots. 
+ * no available reserve slots,etc 
  * 
- * // Client ID: Client Address + Nonce.
- * // It is an identifier IP and Sequence Number 
  * 
- * @param address[IN] Unique string to identify server address,
+ * @param source_addr[IN] source_addr: Client Address + Nonce.
+ * @param destination_addr[IN] Unique string to identify server address,
  * usually IP/Port pair
  * @return connection* If NULL, no connection was achieved
  */
@@ -48,14 +47,14 @@ queue_pair* open(char* source_addr, char* destination_addr);
 
 
 /**
- * @brief Client writes to request queue in given connection.
+ * @brief Client writes to the request queue in given connection.
  * 
  * TODO: 
  * - What if queue full? return 0 for bytes written
  * 
+ * @param conn[IN] queues initialized with server
  * @param buf[IN] data buf to be written
  * @param size[IN] size of buf
- * @param conn[IN] queues initialized with server
  * @return ssize_t -1 for error, >0 for bytes written
  */
 ssize_t send_rpc(queue_pair* conn, const void *buf, size_t size);
@@ -66,14 +65,14 @@ ssize_t send_rpc(queue_pair* conn, const void *buf, size_t size);
  * message queue.
  * 
  * TODO: How do we keep track in the message queue how much has been written?
- * 
+ * TODO: How can we make the implementation zero-copy?
  * 
  * @param conn [IN] queues initialized with server
  * @param buf [IN] data buf to be copied to
  * @param size [IN] size of buf
  * @return ssize_t How much read, if 0 EOF. Only removed from queue once fully read. 
  */
-ssize_t receive_rpc(queue_pair* conn, void** buf, size_t size);
+ssize_t receive_buf(queue_pair* conn, void** buf, size_t size);
 
 
 /**
@@ -87,8 +86,10 @@ ssize_t receive_rpc(queue_pair* conn, void** buf, size_t size);
  * - malformed
  * - ERRNO
  * 
- * @param conn[IN] connection initialized with server
- */
+ * @param source_addr[IN] source_addr: Client Address + Nonce.
+ * @param destination_addr[IN] Unique string to identify server address,
+ * usually IP/Port pair 
+*/
 void close(char* source_addr, char* destination_addr);
 
 
@@ -96,9 +97,8 @@ void close(char* source_addr, char* destination_addr);
 //SERVER
 /**
  * @brief Server will instantiate necessary coord memory regions. 
- * Once instantiate server can begin servicing client requests
- * 
- * 1. Invoked at instantiation of server. Only once per server
+ * Once instantiate server can begin servicing client requests. 
+ * Only once per server
  * 
  * @param source_addr[IN] Unique string to identify desired server address,
  * usually IP/Port pair
@@ -109,31 +109,34 @@ server_context* register_server(char* source_addr);
 
 
 /**
- * @brief
- * 
- * Returns a queue pair corresponding to a client who requested it.
- * Will only service one client per call? In round robin, cycles
- * through currently servicing clients and returns queue pair accordingly.
- * This differs from the usual listen/accept pattern
- * 
- * 1. Needs to be periodically run to service 
- * client requests: open, close
- * 
- * @param handler[IN/OUT] server client connection handler
- */
-queue_pair* listen(server_context* handler);
-
-
-/**
  * @brief 
  * 
  * Service client requests, allocate communication queues, and
- * signal to clients their details. Modifies coord space.
+ * signal to clients their queue details. Modifies coord space.
+ *  * 
+ * 1. Needs to be periodically run to service 
+ * client requests: open, close
+ * 2. Service client requests in order of arrival. 
  * 
  * @param handler [IN/OUT] server client connection handler
+ * 
+ */
+void manage_pool(server_context* handler);
+
+
+/**
+ * @brief
+ * 
+ * Returns a queue pair corresponding to a client who requested it.
+ * Will only service one client per call? In round robin fashion, cycles
+ * through currently servicing clients and returns queue pair accordingly.
+ * This differs from the usual listen/accept pattern.
+ * 
+ * 
+ * @param handler[IN/OUT] server client connection handler
  * @return queue_pair 
  */
-int manage_conn(server_context* handler);
+queue_pair* accept(server_context* handler);
 
 
 /**
@@ -157,29 +160,7 @@ ssize_t send_rpc(queue_pair* client, const void *buf, size_t size);
  * @param size [IN] size of buf
  * @return ssize_t How much read, if 0 EOF. Only removed from queue once fully read. 
  */
-ssize_t receive_rpc(queue_pair* client, void** buf, size_t size);
-
-/**
- * @brief This method is a generic read to read a single incoming request
- * from any client. The order of these reads will depend on a queuing algorithm,
- * ie. round robin, fifo, etc... We can choose to transparent the queuing methodology
- * for whatever consuming system that uses this.
- * TODO: Question: Should read be preallocated? Message size will be determined
- * by the client.
- * TODO: What is the correct way to read incoming messages? There could be 
- * a variety of queuing algorithms we could choose. There is an interesting 
- * opportunity for per connection load balancing at the server level to occur.
- * But for not an algorithm that ensures fairness would be best. Round robin seems
- * like the best and easiest for now, as other algorithms would require greater visibility
- * into the state of the queues. Round robin represents different behavior than how
- * a typical socket read would work, as sockets order messages by delivery (i think). 
- * 
- * @param buf [OUT] data buf for data to be read into
- * @param size [OUT] size of read to be performed
- * @param handler [IN] server client connection handler
- * @return ssize_t -1 for error, >0 for bytes read
- */
-void* receive_next_rpc(size_t *size, server_context* handler, queue_pair** client);
+ssize_t receive_buf(queue_pair* client, void** buf, size_t size);
 
 
 /**

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -57,7 +57,7 @@ queue_pair* open(char* source_addr, char* destination_addr);
  * @param size[IN] size of buf
  * @return ssize_t -1 for error, >0 for bytes written
  */
-ssize_t send_rpc(queue_pair* conn, const void *buf, size_t size);
+int send_rpc(queue_pair* conn, const void *buf, size_t size); //TODO
 
 
 /**
@@ -72,7 +72,7 @@ ssize_t send_rpc(queue_pair* conn, const void *buf, size_t size);
  * @param size [IN] size of buf
  * @return ssize_t How much read, if 0 EOF. Only removed from queue once fully read. 
  */
-ssize_t receive_buf(queue_pair* conn, void** buf, size_t size);
+ssize_t receive_buf(queue_pair* conn, void* buf, size_t size);
 
 
 /**
@@ -147,7 +147,7 @@ queue_pair* accept(server_context* handler);
  * @param size[IN] size of buf
  * @return ssize_t  -1 for error, >0 for bytes written
  */
-ssize_t send_rpc(queue_pair* client, const void *buf, size_t size);
+int send_rpc(queue_pair* client, const void *buf, size_t size);
 
 /**
  * @brief Buffer provided by user. Called until all data has been read from 
@@ -160,7 +160,7 @@ ssize_t send_rpc(queue_pair* client, const void *buf, size_t size);
  * @param size [IN] size of buf
  * @return ssize_t How much read, if 0 EOF. Only removed from queue once fully read. 
  */
-ssize_t receive_buf(queue_pair* client, void** buf, size_t size);
+ssize_t receive_buf(queue_pair* client, void* buf, size_t size);
 
 
 /**


### PR DESCRIPTION
Here is the proposal for the low lever interface for notnets. Names definitely not final, happy to take suggestions on that. 

I would invite your attention to two particular methods that are harder to figure out as their design implies certain implementations.

The first would be notnets_conn_read. The discussion here applies to all read methods. Ideally we would like to avoid a data copy when carrying out a read to share memory however this is complicated to avoid. A discussion is present in the comments.

The second method would be handler_read. This corresponds to the read that a server would carry out on all live connections. The server must have a queuing algorithm to ensure fairness is respected when servicing clients.  A discussion on this follows in the comments. 